### PR TITLE
Add scroll-linked particle hero animation

### DIFF
--- a/app/components/ParticleScene.tsx
+++ b/app/components/ParticleScene.tsx
@@ -1,0 +1,67 @@
+"use client";
+import React, { useRef, useEffect } from "react";
+
+const TOTAL = 3000;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export const ParticleScene: React.FC<{ streams?: number }> = ({ streams = 3 }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const pointsRef = useRef<Point[]>([]);
+  const progressRef = useRef(0);
+
+  useEffect(() => {
+    const radius = 120;
+    const pts: Point[] = [];
+    for (let i = 0; i < TOTAL; i++) {
+      const angle = (i / TOTAL) * Math.PI * 2;
+      pts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+    }
+    pointsRef.current = pts;
+  }, []);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const doc = document.documentElement;
+      const scrollTop = window.scrollY;
+      const docHeight = doc.scrollHeight - window.innerHeight;
+      progressRef.current = docHeight > 0 ? scrollTop / docHeight : 0;
+    };
+    handleScroll();
+    window.addEventListener("scroll", handleScroll);
+
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext("2d")!;
+
+    const render = () => {
+      const w = (canvas.width = canvas.clientWidth);
+      const h = (canvas.height = canvas.clientHeight);
+      ctx.clearRect(0, 0, w, h);
+      const progress = progressRef.current;
+      pointsRef.current.forEach((p, idx) => {
+        const streamIndex = idx % streams;
+        const tx = (streamIndex - (streams - 1) / 2) * 80 * progress;
+        const ty = -progress * h * 0.8;
+        const x = w / 2 + p.x * (1 - progress) + tx;
+        const y = h / 2 + p.y * (1 - progress) + ty;
+        ctx.fillStyle = "rgba(58,153,255,0.75)";
+        ctx.beginPath();
+        ctx.arc(x, y, 1.5, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      requestAnimationFrame(render);
+    };
+
+    requestAnimationFrame(render);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [streams]);
+
+  return <canvas ref={canvasRef} className="w-full h-full" />;
+};
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,14 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/app/components/ui/ca
 import { Header } from '@/app/components/layout/header'
 import { ROICalculator } from '@/app/components/features/roi-calculator'
 import { AnalysisForm } from '@/app/components/features/analysis-form'
+import { ParticleScene } from '@/app/components/ParticleScene'
 import { 
-  Brain, 
-  DollarSign, 
-  Target, 
-  TrendingUp, 
-  Shield,
+  Brain,
+  DollarSign,
+  Target,
+  TrendingUp,
   CheckCircle,
-  Users,
   ArrowRight
 } from 'lucide-react'
 
@@ -18,45 +17,26 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-white">
       <Header />
-      
-      <section className="pt-24 pb-16 bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h1 className="text-5xl md:text-7xl font-bold mb-6">
-              Turn Review Chaos into
-              <span className="bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent block">
-                Revenue Clarity
-              </span>
-            </h1>
-            <p className="text-xl md:text-2xl text-gray-600 mb-8 max-w-3xl mx-auto">
-              AI-powered intelligence that transforms scattered reviews into strategic growth opportunities. 
-              See exactly what reviews are costing you and get the precise actions to fix it.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button size="lg" className="text-lg px-8 py-4">
-                Get Your Free Analysis
-                <ArrowRight className="w-5 h-5 ml-2" />
-              </Button>
-              <Button variant="outline" size="lg" className="text-lg px-8 py-4">
-                Watch Demo
-              </Button>
-            </div>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
-            <div className="flex items-center justify-center gap-2">
-              <Shield className="w-6 h-6 text-green-600" />
-              <span className="text-gray-600">95% Analysis Accuracy</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <Users className="w-6 h-6 text-blue-600" />
-              <span className="text-gray-600">500+ Businesses Analyzed</span>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <TrendingUp className="w-6 h-6 text-purple-600" />
-              <span className="text-gray-600">$2.1M Revenue Identified</span>
-            </div>
-          </div>
+
+      <section
+        id="hero"
+        className="relative h-screen flex flex-col items-center justify-center text-white bg-black overflow-hidden"
+      >
+        <ParticleScene streams={3} />
+
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+          <h1 className="text-5xl font-extrabold drop-shadow-lg text-center">
+            Steal Tomorrow’s Calls—Rise to the Top
+          </h1>
+          <p className="mt-4 text-lg drop-shadow text-center">
+            We measure 200 levers—here are three.
+          </p>
+        </div>
+
+        <div className="absolute bottom-16 opacity-0 animate-fade-in-up delay-[4s]">
+          <button className="bg-gradient-to-r from-purple-500 to-blue-400 px-8 py-3 rounded-full font-semibold">
+            Run My Local Scan
+          </button>
         </div>
       </section>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./lib/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      animation: {
+        "fade-in-up": "fadeInUp 1s ease-out forwards",
+      },
+      keyframes: {
+        fadeInUp: {
+          "0%": { opacity: "0", transform: "translateY(20px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- implement ParticleScene canvas component with scroll-tied particle motion
- integrate ParticleScene into home hero with CTA
- add tailwind config for fade-in-up animation
- remove stray temp page artifact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892812cfca48322a3272b2b74093fbc