### PR TITLE
feat: add live review stream components

### DIFF
--- a/app/api/review-stream/route.ts
+++ b/app/api/review-stream/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const rows = [
+    {
+      id: "1",
+      snippet: "Technician was friendly and fixed the issue quickly.",
+      attributes: [
+        { name: "service", sentiment: "pos" },
+        { name: "speed", sentiment: "pos" },
+      ],
+    },
+    {
+      id: "2",
+      snippet: "Great price but the waiting room was dirty.",
+      attributes: [
+        { name: "pricing", sentiment: "pos" },
+        { name: "cleanliness", sentiment: "neg" },
+      ],
+    },
+    {
+      id: "3",
+      snippet: "Staff were polite though scheduling took forever.",
+      attributes: [
+        { name: "staff", sentiment: "pos" },
+        { name: "scheduling", sentiment: "neg" },
+      ],
+    },
+    {
+      id: "4",
+      snippet: "Average experience, nothing special but acceptable.",
+      attributes: [{ name: "overall", sentiment: "neu" }],
+    },
+  ];
+  return NextResponse.json({ rows });
+}

--- a/app/components/review-stream/attribute-bins.tsx
+++ b/app/components/review-stream/attribute-bins.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useReviewStream } from "./review-stream-provider";
+
+type Sentiment = "pos" | "neu" | "neg";
+interface Flare { id: number; sentiment: Sentiment; x: number; }
+
+function flareColor(s: Sentiment) {
+  switch (s) {
+    case "pos":
+      return "text-emerald-600";
+    case "neg":
+      return "text-rose-600";
+    default:
+      return "text-slate-600";
+  }
+}
+
+export function AttributeBins() {
+  const { bins } = useReviewStream();
+  const prev = useRef<Record<string, { pos: number; neu: number; neg: number }>>({});
+  const [flares, setFlares] = useState<Record<string, Flare[]>>({});
+
+  useEffect(() => {
+    Object.entries(bins).forEach(([attr, counts]) => {
+      const p = prev.current[attr] || { pos: 0, neu: 0, neg: 0 };
+      (Object.keys(counts) as Sentiment[]).forEach((sent) => {
+        const diff = counts[sent] - (p[sent] || 0);
+        if (diff > 0) {
+          for (let i = 0; i < diff; i++) {
+            setFlares((f) => {
+              const arr = f[attr] || [];
+              return {
+                ...f,
+                [attr]: [
+                  ...arr,
+                  { id: Date.now() + Math.random(), sentiment: sent, x: Math.random() * 8 - 4 },
+                ],
+              };
+            });
+          }
+        }
+      });
+    });
+    prev.current = JSON.parse(JSON.stringify(bins));
+  }, [bins]);
+
+  const removeFlare = (attr: string, id: number) => {
+    setFlares((f) => {
+      const arr = (f[attr] || []).filter((fl) => fl.id !== id);
+      return { ...f, [attr]: arr };
+    });
+  };
+
+  return (
+    <div className="flex gap-6">
+      {Object.entries(bins).map(([attr, counts]) => {
+        const total = counts.pos + counts.neu + counts.neg;
+        const posH = total ? (counts.pos / total) * 100 : 0;
+        const neuH = total ? (counts.neu / total) * 100 : 0;
+        const negH = 100 - posH - neuH;
+        return (
+          <div key={attr} className="relative h-40 w-8 flex flex-col items-center">
+            <div className="relative w-8 h-28 bg-slate-200 overflow-hidden">
+              <motion.div
+                className="absolute bottom-0 left-0 w-full bg-emerald-500"
+                animate={{ height: `${posH}%` }}
+                transition={{ type: "spring", duration: 0.5 }}
+              />
+              <motion.div
+                className="absolute left-0 w-full bg-slate-500"
+                animate={{ height: `${neuH}%`, bottom: `${posH}%` }}
+                transition={{ type: "spring", duration: 0.5 }}
+              />
+              <motion.div
+                className="absolute top-0 left-0 w-full bg-rose-500"
+                animate={{ height: `${negH}%` }}
+                transition={{ type: "spring", duration: 0.5 }}
+              />
+            </div>
+            <div className="text-[11px] text-slate-600 mt-1">{attr}</div>
+            <AnimatePresence>
+              {(flares[attr] || []).map((fl) => (
+                <motion.span
+                  key={fl.id}
+                  initial={{ opacity: 1, y: 0 }}
+                  animate={{ opacity: 0, y: -18 }}
+                  transition={{ duration: 0.8 }}
+                  style={{ left: `calc(50% + ${fl.x}px)` }}
+                  className={`absolute bottom-8 text-xs font-semibold ${flareColor(fl.sentiment)}`}
+                  onAnimationComplete={() => removeFlare(attr, fl.id)}
+                >
+                  +1
+                </motion.span>
+              ))}
+            </AnimatePresence>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/app/components/review-stream/review-stream-provider.tsx
+++ b/app/components/review-stream/review-stream-provider.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export interface AttributeChip {
+  name: string;
+  sentiment: "pos" | "neu" | "neg";
+}
+
+export interface ReviewRow {
+  id: string;
+  snippet: string;
+  attributes: AttributeChip[];
+}
+
+interface BinCounts {
+  pos: number;
+  neu: number;
+  neg: number;
+}
+
+interface ReviewStreamCtx {
+  waterfall: ReviewRow[];
+  spotlight: ReviewRow | null;
+  bins: Record<string, BinCounts>;
+  popSpotlight: () => void;
+}
+
+const ReviewStreamContext = createContext<ReviewStreamCtx | null>(null);
+
+export function useReviewStream() {
+  const ctx = useContext(ReviewStreamContext);
+  if (!ctx) throw new Error("useReviewStream must be used within provider");
+  return ctx;
+}
+
+export function ReviewStreamProvider({ children }: { children: ReactNode }) {
+  const [waterfall, setWaterfall] = useState<ReviewRow[]>([]);
+  const [spotlight, setSpotlight] = useState<ReviewRow | null>(null);
+  const [bins, setBins] = useState<Record<string, BinCounts>>({});
+
+  // Fetch new reviews periodically
+  useEffect(() => {
+    const id = setInterval(async () => {
+      if (waterfall.length >= 60) return;
+      try {
+        const res = await fetch("/api/review-stream?batch=100");
+        const j = await res.json();
+        setWaterfall((q) => [...q, ...j.rows]);
+      } catch (err) {
+        console.error(err);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, [waterfall.length]);
+
+  // Promote next review to spotlight periodically
+  useEffect(() => {
+    const id = setInterval(() => {
+      setSpotlight((s) => {
+        if (s || waterfall.length === 0) return s;
+        const [next, ...rest] = waterfall;
+        setWaterfall(rest);
+        return next;
+      });
+    }, 3500);
+    return () => clearInterval(id);
+  }, [waterfall]);
+
+  const popSpotlight = () => setSpotlight(null);
+
+  // Update bins when spotlight changes
+  useEffect(() => {
+    if (!spotlight) return;
+    spotlight.attributes.forEach((a) => {
+      setBins((b) => {
+        const counts = b[a.name] || { pos: 0, neu: 0, neg: 0 };
+        counts[a.sentiment] += 1;
+        return { ...b, [a.name]: counts };
+      });
+    });
+  }, [spotlight]);
+
+  return (
+    <ReviewStreamContext.Provider value={{ waterfall, spotlight, bins, popSpotlight }}>
+      {children}
+    </ReviewStreamContext.Provider>
+  );
+}
+

--- a/app/components/review-stream/spotlight-splitter.tsx
+++ b/app/components/review-stream/spotlight-splitter.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useReviewStream } from "./review-stream-provider";
+
+function sentimentText(sent: "pos" | "neu" | "neg") {
+  switch (sent) {
+    case "pos":
+      return "text-emerald-600";
+    case "neg":
+      return "text-rose-600";
+    default:
+      return "text-slate-600";
+  }
+}
+
+export function SpotlightSplitter() {
+  const { spotlight, popSpotlight } = useReviewStream();
+
+  useEffect(() => {
+    if (!spotlight) return;
+    const t = setTimeout(popSpotlight, 2500);
+    return () => clearTimeout(t);
+  }, [spotlight, popSpotlight]);
+
+  return (
+    <div className="w-[240px] h-[200px] overflow-visible">
+      <AnimatePresence>
+        {spotlight && (
+          <motion.div
+            key={spotlight.id}
+            initial={{ x: -240, y: 0, scale: 0.9, opacity: 0.85 }}
+            animate={{ x: 0, y: [0, -18, 14, 0], scale: 1, opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 1.2, ease: "easeInOut" }}
+            className="relative w-[220px]"
+          >
+            <div className="bg-[#F8FAFC] border-l-[3px] border-slate-300 shadow-sm p-2 backdrop-blur-sm text-[12px] leading-tight">
+              <p className="overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:3] [-webkit-box-orient:vertical]">
+                {spotlight.snippet}
+              </p>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1">
+              {spotlight.attributes.map((a, i) => (
+                <motion.span
+                  key={a.name + i}
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={{ delay: 1.2 + i * 0.07, type: "spring", stiffness: 300, damping: 20 }}
+                  className={`px-2 py-0.5 rounded-full text-[11px] ${sentimentText(a.sentiment)}`}
+                >
+                  {a.name}
+                </motion.span>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+

--- a/app/components/review-stream/waterfall-column.tsx
+++ b/app/components/review-stream/waterfall-column.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useReviewStream } from "./review-stream-provider";
+import { motion } from "framer-motion";
+import { useMemo } from "react";
+
+function FallingCard({ snippet }: { snippet: string }) {
+  const amplitude = useMemo(() => 6 + Math.random() * 10, []);
+  return (
+    <motion.div
+      className="absolute left-0 w-full mb-3"
+      initial={{ y: "-100%", opacity: 0, x: 0 }}
+      animate={{
+        y: "100%",
+        opacity: [0, 0.85, 0.85, 0],
+        x: [0, amplitude, -amplitude, amplitude, 0],
+      }}
+      transition={{
+        y: { duration: 12, ease: "linear" },
+        opacity: { duration: 12, times: [0, 0.083, 0.92, 1] },
+        x: {
+          duration: 6,
+          repeat: Infinity,
+          repeatType: "mirror",
+          ease: "easeInOut",
+        },
+      }}
+    >
+      <div className="bg-[#F8FAFC] bg-opacity-90 backdrop-blur-sm border-l-[3px] border-slate-300 shadow-sm p-2 text-[12px] leading-tight hover:-translate-y-0.5 hover:border-slate-400 transition will-change-transform">
+        <p className="overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:3] [-webkit-box-orient:vertical]">
+          {snippet}
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
+export function WaterfallColumn() {
+  const { waterfall } = useReviewStream();
+  return (
+    <div className="relative w-[220px] h-[400px] overflow-hidden">
+      {waterfall.map((r) => (
+        <FallingCard key={r.id} snippet={r.snippet} />
+      ))}
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,10 @@ import {
   Users,
   ArrowRight
 } from 'lucide-react'
+import { ReviewStreamProvider } from "@/app/components/review-stream/review-stream-provider"
+import { WaterfallColumn } from "@/app/components/review-stream/waterfall-column"
+import { SpotlightSplitter } from "@/app/components/review-stream/spotlight-splitter"
+import { AttributeBins } from "@/app/components/review-stream/attribute-bins"
 
 export default function HomePage() {
   return (
@@ -201,6 +205,21 @@ export default function HomePage() {
             </p>
           </div>
           <ROICalculator />
+        </div>
+      </section>
+
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-4xl font-bold text-center mb-12">Live Voice of the Customer</h2>
+          <ReviewStreamProvider>
+            <div className="flex justify-center items-start gap-12">
+              <WaterfallColumn />
+              <div className="relative">
+                <SpotlightSplitter />
+              </div>
+              <AttributeBins />
+            </div>
+          </ReviewStreamProvider>
         </div>
       </section>
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -15,14 +15,14 @@ export async function createClient() {
         set(name: string, value: string, options: CookieOptions) {
           try {
             cookieStore.set({ name, value, ...options })
-          } catch (error) {
+          } catch {
             // Handle error silently
           }
         },
         remove(name: string, options: CookieOptions) {
           try {
             cookieStore.set({ name, value: '', ...options })
-          } catch (error) {
+          } catch {
             // Handle error silently
           }
         },


### PR DESCRIPTION
## Summary
- add review stream provider and api route for mock review data
- create WaterfallColumn, SpotlightSplitter, and AttributeBins components for animated review visualization
- integrate new live review stream section into homepage
- clean up Supabase server cookie helpers to remove unused error handling

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68927a7f84d083229cb8d2eb3b16d5b2